### PR TITLE
Fix: Resolve multiple import errors causing startup failure.

### DIFF
--- a/core/sun_logic.py
+++ b/core/sun_logic.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from core.location_utils import get_coordinates, get_sun_times
 
 # Hungarian day names list (Monday=0, Sunday=6)
-DAYS_HU_LIST = [
+DAYS_HU = [
     'Hétfő',     # Monday
     'Kedd',      # Tuesday
     'Szerda',    # Wednesday
@@ -27,6 +27,6 @@ def get_hungarian_day_name():
     """Returns the current day's name in Hungarian."""
     day_index = datetime.now().weekday() # Monday is 0 and Sunday is 6
     # Basic safety check, though weekday() should always return 0-6
-    if 0 <= day_index < len(DAYS_HU_LIST):
-        return DAYS_HU_LIST[day_index]
+    if 0 <= day_index < len(DAYS_HU):
+        return DAYS_HU[day_index]
     return "Ismeretlen nap" # Fallback for unexpected index

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -11,21 +11,12 @@ from PySide6.QtCore import Qt, Slot, QTimer, QMetaObject, Q_ARG # QMetaObject é
 from PySide6.QtGui import QIcon, QAction
 
 # Importáljuk az alap ablak osztályt és a GUI managert
-try:
-    # Próbáljuk meg relatívan importálni
-    from .main_window_base import LEDApp_BaseWindow, log_event
-    from .gui_manager import GuiManager # GuiManager importálása
-    # GUI widgetek importálása az isinstance és egyéb hivatkozások miatt
-    from .gui1_pyside import GUI1_Widget
-    from .gui2_schedule_pyside import GUI2_Widget
-    from ..app_utils import load_app_icon # Import the new function
-except ImportError:
-    # Ha nem a 'gui' mappából futtatjuk
-    from main_window_base import LEDApp_BaseWindow, log_event
-    from gui_manager import GuiManager
-    from gui1_pyside import GUI1_Widget
-    from gui2_schedule_pyside import GUI2_Widget
-    from app_utils import load_app_icon # Import the new function (fallback for direct run)
+from .main_window_base import LEDApp_BaseWindow, log_event
+from .gui_manager import GuiManager # GuiManager importálása
+# GUI widgetek importálása az isinstance és egyéb hivatkozások miatt
+from .gui1_pyside import GUI1_Widget
+from .gui2_schedule_pyside import GUI2_Widget
+from app_utils import load_app_icon # Import the new function
 
 class LEDApp_PySide(LEDApp_BaseWindow):
     def __init__(self, start_hidden=False, parent=None): # start_hidden paraméter hozzáadva


### PR DESCRIPTION
This commit addresses several import errors that prevented the application from starting:

1.  Renamed `DAYS_HU_LIST` to `DAYS_HU` in `core/sun_logic.py` and ensured that `gui/gui2_schedule_pyside.py` and `core/reconnect_handler.py` correctly import this variable. This resolves the `ImportError: cannot import name 'DAYS_HU'`.

2.  Corrected import paths in `gui/main_window_pyside.py`:
    *   Changed `from ..app_utils import load_app_icon` to `from app_utils import load_app_icon`. This resolves the `ImportError: attempted relative import beyond top-level package`.
    *   Consolidated imports by removing the try-except block, relying on the corrected direct and relative import paths. This change, along with the `app_utils` fix, should also prevent the subsequent `ModuleNotFoundError: No module named 'main_window_base'` that occurred in the fallback import logic.

These changes should allow the application to initialize its modules correctly.